### PR TITLE
Release 1.1.0 - Folders operations and Share operations

### DIFF
--- a/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
+++ b/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
@@ -56,3 +56,37 @@ export async function createFolder(
 		throw new NodeOperationError(this.getNode(), error, { itemIndex });
 	}
 }
+
+export async function deleteFolder(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	ezlog: (name: string, value: any) => void,
+	credentials: { instanceUrl: string; apiToken: string },
+) {
+	const instanceUrl = credentials.instanceUrl;
+	const realToken = credentials.apiToken;
+
+	const dirId = this.getNodeParameter('dirId', itemIndex, '') as string;
+	if (!dirId) {
+		throw new NodeOperationError(this.getNode(), 'Directory ID is required', { itemIndex });
+	}
+
+	const url = `${instanceUrl}/files/${encodeURIComponent(dirId)}`;
+
+	try {
+		await this.helpers.httpRequest({
+			method: 'DELETE',
+			url,
+			headers: {
+				Authorization: `Bearer ${realToken}`,
+				Accept: 'application/vnd.api+json',
+			},
+			json: true,
+		});
+
+		ezlog('deletedFolderId', dirId);
+		return { deletedFolderId: dirId };
+	} catch (error: any) {
+		throw new NodeOperationError(this.getNode(), error, { itemIndex });
+	}
+}

--- a/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
+++ b/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
@@ -1,0 +1,58 @@
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+export async function createFolder(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	items: INodeExecutionData[],
+	ezlog: (name: string, value: any) => void,
+	credentials: { instanceUrl: string; apiToken: string },
+) {
+	const instanceUrl = credentials.instanceUrl;
+	const realToken = credentials.apiToken;
+
+	const dirName = this.getNodeParameter('dirName', itemIndex, '') as string;
+	const useCustomDir = this.getNodeParameter('dirId', itemIndex, false) as boolean;
+	const targetDirId = useCustomDir
+		? (this.getNodeParameter('dirId', itemIndex, '') as string)
+		: 'io.cozy.files.root-dir';
+
+	if (useCustomDir && !targetDirId) {
+		throw new NodeOperationError(
+			this.getNode(),
+			'Directory ID is required when "Choose Destination Folder" is enabled',
+			{ itemIndex },
+		);
+	}
+
+	const url = `${instanceUrl}/files/${encodeURIComponent(targetDirId)}`;
+	const qs: Record<string, string> = { Type: 'directory', Name: dirName };
+
+	try {
+		const response = await this.helpers.httpRequest({
+			method: 'POST',
+			url,
+			qs,
+			headers: {
+				Authorization: `Bearer ${realToken}`,
+				Accept: 'application/vnd.api+json',
+			},
+			json: true,
+		});
+
+		const createdFolderId = response?.data?.id;
+		if (!createdFolderId) {
+			throw new NodeOperationError(this.getNode(), 'Missing created folder id in response', {
+				itemIndex,
+			});
+		}
+
+		ezlog('createdFolderId', createdFolderId);
+		ezlog('createdFolderParent', targetDirId);
+		ezlog('createdFolder', response?.data);
+
+		return { createdFolderId };
+	} catch (error: any) {
+		throw new NodeOperationError(this.getNode(), error, { itemIndex });
+	}
+}

--- a/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
+++ b/nodes/TwakeDrive/DirectoriesHelpers/DirectoriesHelpers.ts
@@ -136,3 +136,42 @@ export async function moveFolder(
 	ezlog('movedFolderDest', destDirId);
 	return { movedFolderResponse };
 }
+
+export async function renameFolder(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	ezlog: (name: string, value: any) => void,
+	credentials: { instanceUrl: string; apiToken: string },
+) {
+	const instanceUrl = credentials.instanceUrl;
+	const realToken = credentials.apiToken;
+	const folderId = this.getNodeParameter('folderId', itemIndex, '') as string;
+	const newFolderName = this.getNodeParameter('newFolderName', itemIndex, '') as string;
+	if (!folderId) {
+		throw new NodeOperationError(this.getNode(), 'Folder ID is required', { itemIndex });
+	}
+	if (!newFolderName) {
+		throw new NodeOperationError(this.getNode(), 'New Folder Name is required', { itemIndex });
+	}
+	const url = `${instanceUrl}/files/${encodeURIComponent(folderId)}`;
+	const renameResponse = await this.helpers.httpRequest({
+		method: 'PATCH',
+		url,
+		headers: {
+			Authorization: `Bearer ${realToken}`,
+			Accept: 'application/vnd.api+json',
+			'Content-Type': 'application/vnd.api+json',
+		},
+		body: JSON.stringify({
+			data: {
+				type: 'io.cozy.files',
+				id: folderId,
+				attributes: { name: newFolderName },
+			},
+		}),
+		json: true,
+	});
+	ezlog('renamedFolderId', folderId);
+	ezlog('renamedFolderNewName', newFolderName);
+	return { renameResponse };
+}

--- a/nodes/TwakeDrive/FilesHelpers/FilesHelpers.ts
+++ b/nodes/TwakeDrive/FilesHelpers/FilesHelpers.ts
@@ -25,12 +25,62 @@ export async function getOneFile(
 
 export async function listFiles(
 	this: IExecuteFunctions,
+	itemIndex: number,
 	ezlog: (name: string, value: any) => void,
 	credentials: { instanceUrl: string; apiToken: string },
 ) {
 	const instanceUrl = credentials.instanceUrl;
-	const fileListUrl = `${instanceUrl}/data/io.cozy.files/_all_docs?include_docs=true&Fields=name,metadata,type,id,cozyMetadata`;
 	const realToken = credentials.apiToken;
+
+	const listMode = this.getNodeParameter('listMode', itemIndex, 'all') as string;
+	const listDirId = this.getNodeParameter('listDirId', itemIndex, '') as string;
+	// BY DIRECTORY MODE
+	if (listMode === 'byDirectory') {
+		if (!listDirId) {
+			throw new NodeOperationError(
+				this.getNode(),
+				'Directory ID is required for "Folder contents"',
+				{ itemIndex },
+			);
+		}
+
+		const wantedFilesArray: any[] = [];
+		let cursor: string | null = null;
+
+		while (true) {
+			const qs: Record<string, string | number> = {};
+			// limited to 30 (cozy API default), can be increase
+			qs['page[limit]'] = 30;
+			if (cursor) qs['page[cursor]'] = cursor;
+
+			const resp = await this.helpers.httpRequest({
+				method: 'GET',
+				url: `${instanceUrl}/files/${encodeURIComponent(listDirId)}`,
+				qs,
+				headers: {
+					Authorization: `Bearer ${realToken}`,
+					Accept: 'application/vnd.api+json',
+				},
+				json: true,
+			});
+
+			const chunk = Array.isArray(resp?.included) ? resp.included : [];
+			if (chunk.length) wantedFilesArray.push(...chunk);
+
+			const nextPageLink = resp?.links?.next as string | undefined;
+			cursor = nextPageLink
+				? new URL(nextPageLink, instanceUrl).searchParams.get('page[cursor]')
+				: null;
+			if (!cursor) break;
+		}
+
+		ezlog('listByDirectory.total', wantedFilesArray.length);
+		ezlog('listByDirectory.files', wantedFilesArray);
+		return { wantedFilesArray };
+	}
+	// ALL MODE
+	const fileListUrl = `${instanceUrl}/data/io.cozy.files/_all_docs?include_docs=true&Fields=name,metadata,type,id,cozyMetadata`;
+
 	const filesListResponse = await this.helpers.httpRequest({
 		method: 'GET',
 		url: fileListUrl,
@@ -40,9 +90,9 @@ export async function listFiles(
 		},
 		json: true,
 	});
-	ezlog('fileListResponse', filesListResponse);
-	const docsArray = filesListResponse.rows;
-	const wantedFilesArray = [];
+
+	const docsArray = filesListResponse?.rows ?? [];
+	const wantedFilesArray: any[] = [];
 	for (let i = 0; i < docsArray.length; i++) {
 		wantedFilesArray.push(docsArray[i]);
 	}

--- a/nodes/TwakeDrive/SharingHelpers/SharingHelpers.ts
+++ b/nodes/TwakeDrive/SharingHelpers/SharingHelpers.ts
@@ -1,0 +1,85 @@
+import { IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+
+export async function shareByLink(
+	this: IExecuteFunctions,
+	itemIndex: number,
+	ezlog: (name: string, value: any) => void,
+	credentials: { instanceUrl: string; apiToken: string },
+) {
+	const instanceUrl = credentials.instanceUrl;
+	const realToken = credentials.apiToken;
+
+	const id = this.getNodeParameter('fileOrDirId', itemIndex, '') as string;
+	if (!id) {
+		throw new NodeOperationError(this.getNode(), 'File or Directory ID is required', { itemIndex });
+	}
+
+	const accessLevel = this.getNodeParameter('accessLevel', itemIndex, 'read') as 'read' | 'write';
+	const useTtl = this.getNodeParameter('useTtl', itemIndex, false) as boolean;
+	const amount = this.getNodeParameter('expiryDuration.duration.amount', itemIndex, 0) as number;
+	const unit = this.getNodeParameter('expiryDuration.duration.unit', itemIndex, '') as string;
+	const usePassword = this.getNodeParameter('usePassword', itemIndex, false) as boolean;
+	const sharePassword = (this.getNodeParameter('sharePassword', itemIndex, '') as string).trim();
+	const codesCsv = (this.getNodeParameter('codes', itemIndex, 'link') as string).trim();
+
+	const verbs = accessLevel === 'write' ? ['GET', 'POST', 'PATCH', 'DELETE'] : ['GET'];
+
+	const qs: Record<string, string> = {};
+	if (codesCsv) qs['codes'] = codesCsv;
+	if (useTtl) {
+		if (!amount || !unit) {
+			throw new NodeOperationError(this.getNode(), 'Duration amount and unit are required', {
+				itemIndex,
+			});
+		}
+		qs['ttl'] = `${amount}${unit}`;
+	}
+
+	const body = {
+		data: {
+			type: 'io.cozy.permissions',
+			attributes: {
+				permissions: {
+					files: {
+						type: 'io.cozy.files',
+						values: [id],
+						verbs,
+					},
+				},
+				...(usePassword && sharePassword ? { password: sharePassword } : {}),
+			},
+		},
+	};
+
+	try {
+		const resp = await this.helpers.httpRequest({
+			method: 'POST',
+			url: `${instanceUrl}/permissions`,
+			qs,
+			headers: {
+				Authorization: `Bearer ${realToken}`,
+				Accept: 'application/vnd.api+json',
+				'Content-Type': 'application/vnd.api+json',
+			},
+			body,
+			json: true,
+		});
+
+		const permissionsId = resp?.data?.id ?? null;
+		const shortcodes = resp?.data?.attributes?.shortcodes ?? null;
+		const u = new URL(instanceUrl);
+		const driveBase = `${u.protocol}//drive.${u.host}`;
+		const shareUrls: Record<string, string> = {};
+		if (shortcodes && typeof shortcodes === 'object') {
+			for (const [label, personalToken] of Object.entries(shortcodes as Record<string, string>)) {
+				shareUrls[label] = `${driveBase}/public?sharecode=${personalToken}`;
+			}
+		}
+		ezlog('share.urls', shareUrls);
+		ezlog('share.permissionsId', permissionsId);
+
+		return { share: { permissionsId, shareUrls } };
+	} catch (error: any) {
+		throw new NodeOperationError(this.getNode(), error, { itemIndex });
+	}
+}

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -6,6 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import * as TwakeFilesHelpers from './FilesHelpers/FilesHelpers';
+import { createEzlog } from './utils/ezlog';
 
 export class TwakeDriveNode implements INodeType {
 	description: INodeTypeDescription = {
@@ -212,15 +213,9 @@ export class TwakeDriveNode implements INodeType {
 		const credentials = (await this.getCredentials('twakeDriveApi')) as TwakeCredentials;
 
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
-			function saveItem(items: any, itemIndex: any) {
-				return function (name: string, value: any) {
-					items[itemIndex].json[name] = value;
-				};
-			}
-			const ezlog = saveItem(items, itemIndex);
+			const ezlog = createEzlog(items as INodeExecutionData[], itemIndex);
 			try {
 				const operation = this.getNodeParameter('operation', itemIndex) as string;
-
 				switch (operation) {
 					// FILES OPERATIONS
 					case 'getOneFile':

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -100,6 +100,12 @@ export class TwakeDriveNode implements INodeType {
 						description: 'Delete the selected directory in the Twake instance',
 						action: 'Delete the selected directory in the twake instance',
 					},
+					{
+						name: 'Move Folder',
+						value: 'moveFolder',
+						description: 'Move the selected folder to another directory',
+						action: 'Move the selected folder to another directory',
+					},
 				],
 
 				default: 'listFiles',
@@ -135,7 +141,7 @@ export class TwakeDriveNode implements INodeType {
 				default: false,
 				displayOptions: {
 					show: {
-						operation: ['copyFile', 'createFileFromText', 'moveFile', 'createFolder'],
+						operation: ['copyFile', 'createFileFromText', 'moveFile', 'createFolder', 'moveFolder'],
 					},
 				},
 			},
@@ -147,7 +153,14 @@ export class TwakeDriveNode implements INodeType {
 				description: 'ID of the targeted directory',
 				displayOptions: {
 					show: {
-						operation: ['uploadFile', 'copyFile', 'createFileFromText', 'moveFile', 'createFolder'],
+						operation: [
+							'uploadFile',
+							'copyFile',
+							'createFileFromText',
+							'moveFile',
+							'createFolder',
+							'moveFolder',
+						],
 						customDir: [true],
 					},
 				},
@@ -230,6 +243,18 @@ export class TwakeDriveNode implements INodeType {
 					},
 				},
 			},
+			{
+				displayName: 'Folder ID',
+				name: 'folderId',
+				type: 'string',
+				default: '',
+				description: 'ID of the folder to move or rename',
+				displayOptions: {
+					show: {
+						operation: ['moveFolder'],
+					},
+				},
+			},
 		],
 	};
 
@@ -287,6 +312,9 @@ export class TwakeDriveNode implements INodeType {
 						break;
 					case 'deleteFolder':
 						await TwakeDirectoriesHelpers.deleteFolder.call(this, itemIndex, ezlog, credentials);
+						break;
+					case 'moveFolder':
+						await TwakeDirectoriesHelpers.moveFolder.call(this, itemIndex, ezlog, credentials);
 						break;
 				}
 			} catch (error) {

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -6,6 +6,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import * as TwakeFilesHelpers from './FilesHelpers/FilesHelpers';
+import * as TwakeDirectoriesHelpers from './DirectoriesHelpers/DirectoriesHelpers';
 import { createEzlog } from './utils/ezlog';
 
 export class TwakeDriveNode implements INodeType {
@@ -35,6 +36,7 @@ export class TwakeDriveNode implements INodeType {
 				type: 'options',
 				noDataExpression: true,
 				options: [
+					// FILES OPERATIONS
 					{
 						name: 'Copy File',
 						value: 'copyFile',
@@ -84,6 +86,14 @@ export class TwakeDriveNode implements INodeType {
 						description: 'Upload a received file in the Twake instance in designated directory',
 						action: 'Upload a received file in the twake instance in designated directory',
 					},
+					// DIRECTORIES OPERATION
+					{
+						name: 'Create Folder',
+						value: 'createFolder',
+						description:
+							'Create a new directory in the Twake instance. Destination directory can be specified',
+						action: 'Create a new directory in the twake instance',
+					},
 				],
 
 				default: 'listFiles',
@@ -119,7 +129,7 @@ export class TwakeDriveNode implements INodeType {
 				default: false,
 				displayOptions: {
 					show: {
-						operation: ['copyFile', 'createFileFromText', 'moveFile'],
+						operation: ['copyFile', 'createFileFromText', 'moveFile', 'createFolder'],
 					},
 				},
 			},
@@ -131,7 +141,7 @@ export class TwakeDriveNode implements INodeType {
 				description: 'ID of the targeted directory',
 				displayOptions: {
 					show: {
-						operation: ['uploadFile', 'copyFile', 'createFileFromText', 'moveFile'],
+						operation: ['uploadFile', 'copyFile', 'createFileFromText', 'moveFile', 'createFolder'],
 						customDir: [true],
 					},
 				},
@@ -201,6 +211,19 @@ export class TwakeDriveNode implements INodeType {
 					},
 				},
 			},
+			{
+				displayName: 'Directory Name',
+				name: 'dirName',
+				type: 'string',
+				default: '',
+				placeholder: 'My new folder',
+				description: 'Name of the directory to create',
+				displayOptions: {
+					show: {
+						operation: ['createFolder'],
+					},
+				},
+			},
 		],
 	};
 
@@ -242,6 +265,17 @@ export class TwakeDriveNode implements INodeType {
 					case 'updateFile':
 						await TwakeFilesHelpers.updateFile.call(this, itemIndex, items, ezlog, credentials);
 						break;
+					// DIRECTORIES OPERATIONS
+					case 'createFolder': {
+						await TwakeDirectoriesHelpers.createFolder.call(
+							this,
+							itemIndex,
+							items,
+							ezlog,
+							credentials,
+						);
+						break;
+					}
 				}
 			} catch (error) {
 				ezlog('errorMessage', error.message);

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -33,12 +33,27 @@ export class TwakeDriveNode implements INodeType {
 		usableAsTool: true,
 		properties: [
 			{
+				displayName: 'Resource',
+				name: 'resource',
+				type: 'options',
+				noDataExpression: true,
+				default: 'file',
+				options: [
+					{ name: 'File', value: 'file' },
+					{ name: 'Folder', value: 'folder' },
+					{ name: 'Share', value: 'share' },
+				],
+				description: 'Select the type of item to operate on',
+			},
+			// Operation — FILE
+			{
 				displayName: 'Operation',
 				name: 'operation',
 				type: 'options',
 				noDataExpression: true,
+				default: 'listFiles',
+				displayOptions: { show: { resource: ['file'] } },
 				options: [
-					// FILES OPERATIONS
 					{
 						name: 'Copy File',
 						value: 'copyFile',
@@ -88,12 +103,22 @@ export class TwakeDriveNode implements INodeType {
 						description: 'Upload a received file in the Twake instance in designated directory',
 						action: 'Upload a received file in the twake instance in designated directory',
 					},
-					// DIRECTORIES OPERATIONS
+				],
+			},
+			// Operation — FOLDER
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				default: 'createFolder',
+				displayOptions: { show: { resource: ['folder'] } },
+				options: [
 					{
 						name: 'Create Folder',
 						value: 'createFolder',
 						description:
-							'Create a new directory in the Twake instance. Destination directory can be specified',
+							'Create a new directory in the Twake instance. Destination directory can be specified.',
 						action: 'Create a new directory in the twake instance',
 					},
 					{
@@ -114,23 +139,32 @@ export class TwakeDriveNode implements INodeType {
 						description: 'Rename the selected folder',
 						action: 'Rename the selected folder',
 					},
-					// SHARING OPERATIONS
-					{
-						name: 'Share by Link (File or Folder)',
-						value: 'shareByLink',
-						description: 'Create a share link for a file or a folder',
-						action: 'Create a share link for a file or a folder',
-					},
+				],
+			},
+			// Operation — SHARE
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				default: 'shareByLink',
+				displayOptions: { show: { resource: ['share'] } },
+				options: [
 					{
 						name: 'Delete Share (by Permissions ID)',
 						value: 'deleteShare',
 						description: 'Delete a share by its permissions ID (revokes all codes)',
 						action: 'Delete a share by its permissions ID',
 					},
+					{
+						name: 'Share by Link (File or Folder)',
+						value: 'shareByLink',
+						description: 'Create a share link for a file or a folder',
+						action: 'Create a share link for a file or a folder',
+					},
 				],
-
-				default: 'listFiles',
 			},
+
 			{
 				displayName: 'File or Directory ID',
 				name: 'fileOrDirId',
@@ -144,7 +178,7 @@ export class TwakeDriveNode implements INodeType {
 				},
 			},
 			{
-				displayName: 'Permissions ID',
+				displayName: 'Permissions Name or ID',
 				name: 'permissionsId',
 				type: 'options',
 				typeOptions: {
@@ -152,7 +186,8 @@ export class TwakeDriveNode implements INodeType {
 				},
 				default: '',
 				required: true,
-				description: 'Select the share to delete (labels · id)',
+				description:
+					'Select the share to delete (labels · ID). Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 				displayOptions: { show: { operation: ['deleteShare'] } },
 			},
 			{
@@ -160,11 +195,11 @@ export class TwakeDriveNode implements INodeType {
 				name: 'useLabels',
 				type: 'boolean',
 				default: false,
-				description: 'ON: revoke only selected labels. OFF: delete the whole share',
+				description: 'Whether to revoke only selected labels. When disabled, the entire share is deleted.',
 				displayOptions: { show: { operation: ['deleteShare'] } },
 			},
 			{
-				displayName: 'Labels to Revoke (optional)',
+				displayName: 'Labels to Revoke (Optional)',
 				name: 'labelsToRevoke',
 				type: 'multiOptions',
 				typeOptions: {
@@ -172,10 +207,9 @@ export class TwakeDriveNode implements INodeType {
 					loadOptionsDependsOn: ['permissionsId'],
 				},
 				default: [],
-				required: false,
 				placeholder: 'Leave empty to delete the entire share',
 				description:
-					'Select labels to revoke. If empty (or switch OFF), the entire share is deleted',
+					'Select labels to revoke. If empty (or switch OFF), the entire share is deleted. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 				displayOptions: { show: { operation: ['deleteShare'], useLabels: [true] } },
 			},
 
@@ -185,8 +219,8 @@ export class TwakeDriveNode implements INodeType {
 				type: 'options',
 				default: 'read',
 				options: [
-					{ name: 'Read-only', value: 'read' },
-					{ name: 'Can edit', value: 'write' },
+					{ name: 'Read-Only', value: 'read' },
+					{ name: 'Can Edit', value: 'write' },
 				],
 				displayOptions: { show: { operation: ['shareByLink'] } },
 			},
@@ -222,11 +256,11 @@ export class TwakeDriveNode implements INodeType {
 								type: 'options',
 								default: 's',
 								options: [
-									{ name: 'Seconds', value: 's' },
-									{ name: 'Minutes', value: 'm' },
-									{ name: 'Hours', value: 'h' },
 									{ name: 'Days', value: 'D' },
+									{ name: 'Hours', value: 'h' },
+									{ name: 'Minutes', value: 'm' },
 									{ name: 'Months', value: 'M' },
+									{ name: 'Seconds', value: 's' },
 									{ name: 'Years', value: 'Y' },
 								],
 							},
@@ -251,13 +285,13 @@ export class TwakeDriveNode implements INodeType {
 				displayOptions: { show: { operation: ['shareByLink'], usePassword: [true] } },
 			},
 			{
-				displayName: 'Codes (Comma-separated labels)',
+				displayName: 'Codes (Comma-Separated Labels)',
 				name: 'codes',
 				type: 'string',
 				default: '',
 				placeholder: 'e.g. link or clientA,clientB ...',
 				description:
-					'Comma-separated labels; This will be the key(s) of the created codes, each creates a separate link that can be revoked independently.',
+					'Comma-separated labels; This will be the key(s) of the created codes, each creates a separate link that can be revoked independently',
 				displayOptions: { show: { operation: ['shareByLink'] } },
 			},
 
@@ -289,7 +323,7 @@ export class TwakeDriveNode implements INodeType {
 				name: 'dirId',
 				type: 'string',
 				default: '',
-				description: 'ID of the targeted directory',
+				description: 'ID of the destination directory',
 				displayOptions: {
 					show: {
 						operation: [
@@ -375,8 +409,8 @@ export class TwakeDriveNode implements INodeType {
 				type: 'options',
 				default: 'all',
 				options: [
-					{ name: 'All files', value: 'all' },
-					{ name: 'Folder contents', value: 'byDirectory' },
+					{ name: 'All Files', value: 'all' },
+					{ name: 'Folder Contents', value: 'byDirectory' },
 				],
 				displayOptions: { show: { operation: ['listFiles'] } },
 			},

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -94,6 +94,12 @@ export class TwakeDriveNode implements INodeType {
 							'Create a new directory in the Twake instance. Destination directory can be specified',
 						action: 'Create a new directory in the twake instance',
 					},
+					{
+						name: 'Delete Folder',
+						value: 'deleteFolder',
+						description: 'Delete the selected directory in the Twake instance',
+						action: 'Delete the selected directory in the twake instance',
+					},
 				],
 
 				default: 'listFiles',
@@ -154,7 +160,7 @@ export class TwakeDriveNode implements INodeType {
 				description: 'ID of the targeted directory',
 				displayOptions: {
 					show: {
-						operation: ['uploadFile'],
+						operation: ['uploadFile', 'deleteFolder'],
 					},
 				},
 			},
@@ -240,7 +246,9 @@ export class TwakeDriveNode implements INodeType {
 			try {
 				const operation = this.getNodeParameter('operation', itemIndex) as string;
 				switch (operation) {
-					// FILES OPERATIONS
+					//////////////////////
+					// FILES OPERATIONS //
+					//////////////////////
 					case 'getOneFile':
 						await TwakeFilesHelpers.getOneFile.call(this, itemIndex, ezlog, credentials);
 						break;
@@ -265,8 +273,10 @@ export class TwakeDriveNode implements INodeType {
 					case 'updateFile':
 						await TwakeFilesHelpers.updateFile.call(this, itemIndex, items, ezlog, credentials);
 						break;
-					// DIRECTORIES OPERATIONS
-					case 'createFolder': {
+					////////////////////////////
+					// DIRECTORIES OPERATIONS //
+					////////////////////////////
+					case 'createFolder':
 						await TwakeDirectoriesHelpers.createFolder.call(
 							this,
 							itemIndex,
@@ -275,7 +285,9 @@ export class TwakeDriveNode implements INodeType {
 							credentials,
 						);
 						break;
-					}
+					case 'deleteFolder':
+						await TwakeDirectoriesHelpers.deleteFolder.call(this, itemIndex, ezlog, credentials);
+						break;
 				}
 			} catch (error) {
 				ezlog('errorMessage', error.message);

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -237,6 +237,27 @@ export class TwakeDriveNode implements INodeType {
 				},
 			},
 			{
+				displayName: 'Listing Mode',
+				name: 'listMode',
+				type: 'options',
+				default: 'all',
+				options: [
+					{ name: 'All files', value: 'all' },
+					{ name: 'Folder contents', value: 'byDirectory' },
+				],
+				displayOptions: { show: { operation: ['listFiles'] } },
+			},
+			{
+				displayName: 'Directory ID',
+				name: 'listDirId',
+				type: 'string',
+				default: '',
+				description: 'ID of the directory to list',
+				displayOptions: {
+					show: { operation: ['listFiles'], listMode: ['byDirectory'] },
+				},
+			},
+			{
 				displayName: 'Directory Name',
 				name: 'dirName',
 				type: 'string',
@@ -297,7 +318,7 @@ export class TwakeDriveNode implements INodeType {
 						await TwakeFilesHelpers.getOneFile.call(this, itemIndex, ezlog, credentials);
 						break;
 					case 'listFiles':
-						await TwakeFilesHelpers.listFiles.call(this, ezlog, credentials);
+						await TwakeFilesHelpers.listFiles.call(this, itemIndex, ezlog, credentials);
 						break;
 					case 'uploadFile':
 						await TwakeFilesHelpers.uploadFile.call(this, itemIndex, items, ezlog, credentials);

--- a/nodes/TwakeDrive/TwakeDriveNode.node.ts
+++ b/nodes/TwakeDrive/TwakeDriveNode.node.ts
@@ -106,6 +106,12 @@ export class TwakeDriveNode implements INodeType {
 						description: 'Move the selected folder to another directory',
 						action: 'Move the selected folder to another directory',
 					},
+					{
+						name: 'Rename Folder',
+						value: 'renameFolder',
+						description: 'Rename the selected folder',
+						action: 'Rename the selected folder',
+					},
 				],
 
 				default: 'listFiles',
@@ -251,7 +257,20 @@ export class TwakeDriveNode implements INodeType {
 				description: 'ID of the folder to move or rename',
 				displayOptions: {
 					show: {
-						operation: ['moveFolder'],
+						operation: ['moveFolder', 'renameFolder'],
+					},
+				},
+			},
+			{
+				displayName: 'New Folder Name',
+				name: 'newFolderName',
+				type: 'string',
+				default: '',
+				placeholder: 'My renamed folder',
+				description: 'New name for the folder',
+				displayOptions: {
+					show: {
+						operation: ['renameFolder'],
 					},
 				},
 			},
@@ -315,6 +334,9 @@ export class TwakeDriveNode implements INodeType {
 						break;
 					case 'moveFolder':
 						await TwakeDirectoriesHelpers.moveFolder.call(this, itemIndex, ezlog, credentials);
+						break;
+					case 'renameFolder':
+						await TwakeDirectoriesHelpers.renameFolder.call(this, itemIndex, ezlog, credentials);
 						break;
 				}
 			} catch (error) {

--- a/nodes/TwakeDrive/utils/ezlog.ts
+++ b/nodes/TwakeDrive/utils/ezlog.ts
@@ -1,0 +1,8 @@
+import type { INodeExecutionData } from 'n8n-workflow';
+
+export function createEzlog(items: INodeExecutionData[], itemIndex: number) {
+	return function (name: string, value: any) {
+		if (!items[itemIndex].json) items[itemIndex].json = {};
+		items[itemIndex].json[name] = value;
+	};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "n8n-nodes-twakedrive",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "Custom community node to interact with Twake Drive",
 	"keywords": [
 		"n8n-community-node-package"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
 		]
 	},
 	"devDependencies": {
+		"@types/node": "^24.2.1",
 		"@typescript-eslint/parser": "~8.32.0",
 		"eslint": "^8.57.0",
 		"eslint-plugin-n8n-nodes-base": "^1.16.3",
 		"gulp": "^5.0.0",
+		"n8n-workflow": "^1.82.0",
 		"prettier": "^3.5.3",
 		"typescript": "^5.8.2"
 	},


### PR DESCRIPTION
### 1.1.0

- Using OAuth to get an app token instead of an admin token
- Folders operations (as listed above)
- Shares operations (as listed above)
- Add "byDirectory" option on `listFiles` operation
- Move `ezlog` (Little function to save an item during execution) in `/utils` folder for clarity
- Split operations in ressource categories in the n8n UI